### PR TITLE
docs: add chmod-reference.md to cheatsheets

### DIFF
--- a/cheatsheets/chmod-reference.md
+++ b/cheatsheets/chmod-reference.md
@@ -1,0 +1,11 @@
+# `chmod` Quick Reference
+
+Common `chmod` permissions with meanings and typical use.
+
+| Octal | Meaning (Owner / Group / Others) | Common Use     |
+| ----- | -------------------------------- | -------------- |
+| `600` | rw- / --- / ---                  | Private file (only owner can read/write, e.g. `authorized_keys`)         |
+| `644` | rw- / r-- / r--                  | Public-readable files (e.g. web files, configs)                          |
+| `700` | rwx / --- / ---                  | Private directory (only owner can enter/traverse)                             |
+| `755` | rwx / r-x / r-x                  | Public directories/executables (everyone can traverse, owner can modify) |
+| `777` | rwx / rwx / rwx                  | Full access for all (**RARELY SAFE** avoid unless temporary test)        |


### PR DESCRIPTION
## What
Add a quick reference doc for common `chmod` permissions.

## Why
To serve as a simple lookup while learning file permissions and building muscle memory.

## Notes
Closes #9
